### PR TITLE
Add all telegram bot api types and methods

### DIFF
--- a/src/bot-api/methods.ts
+++ b/src/bot-api/methods.ts
@@ -56,6 +56,105 @@ const getUpdates = defineMethod({
 })
 
 const setWebhook = $todo()
+const deleteWebhook = $todo()
+const getWebhookInfo = $todo()
+const getMe = $todo()
+const logOut = $todo()
+const close = $todo()
+const sendMessage = $todo()
+const forwardMessage = $todo()
+const copyMessage = $todo()
+const sendPhoto = $todo()
+const sendAudio = $todo()
+const sendDocument = $todo()
+const sendVideo = $todo()
+const sendAnimation = $todo()
+const sendVoice = $todo()
+const sendVideoNote = $todo()
+const sendMediaGroup = $todo()
+const sendLocation = $todo()
+const editMessageLiveLocation = $todo()
+const stopMessageLiveLocation = $todo()
+const sendVenue = $todo()
+const sendContact = $todo()
+const sendPoll = $todo()
+const sendDice = $todo()
+const sendChatAction = $todo()
+const getUserProfilePhotos = $todo()
+const getFile = $todo()
+const banChatMember = $todo()
+const unbanChatMember = $todo()
+const restrictChatMember = $todo()
+const promoteChatMember = $todo()
+const setChatAdministratorCustomTitle = $todo()
+const banChatSenderChat = $todo()
+const unbanChatSenderChat = $todo()
+const setChatPermissions = $todo()
+const exportChatInviteLink = $todo()
+const createChatInviteLink = $todo()
+const editChatInviteLink = $todo()
+const revokeChatInviteLink = $todo()
+const approveChatJoinRequest = $todo()
+const declineChatJoinRequest = $todo()
+const setChatPhoto = $todo()
+const deleteChatPhoto = $todo()
+const setChatTitle = $todo()
+const setChatDescription = $todo()
+const pinChatMessage = $todo()
+const unpinChatMessage = $todo()
+const unpinAllChatMessages = $todo()
+const leaveChat = $todo()
+const getChat = $todo()
+const getChatAdministrators = $todo()
+const getChatMemberCount = $todo()
+const getChatMember = $todo()
+const setChatStickerSet = $todo()
+const deleteChatStickerSet = $todo()
+const answerCallbackQuery = $todo()
+const setMyCommands = $todo()
+const deleteMyCommands = $todo()
+const getMyCommands = $todo()
+const setMyName = $todo()
+const getMyName = $todo()
+const setMyDescription = $todo()
+const getMyDescription = $todo()
+const setMyShortDescription = $todo()
+const getMyShortDescription = $todo()
+const setChatMenuButton = $todo()
+const getChatMenuButton = $todo()
+const setMyDefaultAdministratorRights = $todo()
+const getMyDefaultAdministratorRights = $todo()
+const editMessageText = $todo()
+const editMessageCaption = $todo()
+const editMessageMedia = $todo()
+const editMessageReplyMarkup = $todo()
+const stopPoll = $todo()
+const deleteMessage = $todo()
+const sendSticker = $todo()
+const getStickerSet = $todo()
+const getCustomEmojiStickers = $todo()
+const uploadStickerFile = $todo()
+const createNewStickerSet = $todo()
+const addStickerToSet = $todo()
+const setStickerPositionInSet = $todo()
+const deleteStickerFromSet = $todo()
+const setStickerEmojiList = $todo()
+const setStickerKeywords = $todo()
+const setStickerMaskPosition = $todo()
+const setStickerSetTitle = $todo()
+const setStickerSetThumbnail = $todo()
+const setCustomEmojiStickerSetThumbnail = $todo()
+const deleteStickerSet = $todo()
+const answerInlineQuery = $todo()
+const answerWebAppQuery = $todo()
+const sendInvoice = $todo()
+const createInvoiceLink = $todo()
+const answerShippingQuery = $todo()
+const answerPreCheckoutQuery = $todo()
+const setPassportDataErrors = $todo()
+const sendGame = $todo()
+const setGameScore = $todo()
+const getGameHighScores = $todo()
 
 /**
  * Definition of all Bot API methods as an object.
@@ -63,6 +162,105 @@ const setWebhook = $todo()
 export const object = {
   getUpdates,
   setWebhook,
+  deleteWebhook,
+  getWebhookInfo,
+  getMe,
+  logOut,
+  close,
+  sendMessage,
+  forwardMessage,
+  copyMessage,
+  sendPhoto,
+  sendAudio,
+  sendDocument,
+  sendVideo,
+  sendAnimation,
+  sendVoice,
+  sendVideoNote,
+  sendMediaGroup,
+  sendLocation,
+  editMessageLiveLocation,
+  stopMessageLiveLocation,
+  sendVenue,
+  sendContact,
+  sendPoll,
+  sendDice,
+  sendChatAction,
+  getUserProfilePhotos,
+  getFile,
+  banChatMember,
+  unbanChatMember,
+  restrictChatMember,
+  promoteChatMember,
+  setChatAdministratorCustomTitle,
+  banChatSenderChat,
+  unbanChatSenderChat,
+  setChatPermissions,
+  exportChatInviteLink,
+  createChatInviteLink,
+  editChatInviteLink,
+  revokeChatInviteLink,
+  approveChatJoinRequest,
+  declineChatJoinRequest,
+  setChatPhoto,
+  deleteChatPhoto,
+  setChatTitle,
+  setChatDescription,
+  pinChatMessage,
+  unpinChatMessage,
+  unpinAllChatMessages,
+  leaveChat,
+  getChat,
+  getChatAdministrators,
+  getChatMemberCount,
+  getChatMember,
+  setChatStickerSet,
+  deleteChatStickerSet,
+  answerCallbackQuery,
+  setMyCommands,
+  deleteMyCommands,
+  getMyCommands,
+  setMyName,
+  getMyName,
+  setMyDescription,
+  getMyDescription,
+  setMyShortDescription,
+  getMyShortDescription,
+  setChatMenuButton,
+  getChatMenuButton,
+  setMyDefaultAdministratorRights,
+  getMyDefaultAdministratorRights,
+  editMessageText,
+  editMessageCaption,
+  editMessageMedia,
+  editMessageReplyMarkup,
+  stopPoll,
+  deleteMessage,
+  sendSticker,
+  getStickerSet,
+  getCustomEmojiStickers,
+  uploadStickerFile,
+  createNewStickerSet,
+  addStickerToSet,
+  setStickerPositionInSet,
+  deleteStickerFromSet,
+  setStickerEmojiList,
+  setStickerKeywords,
+  setStickerMaskPosition,
+  setStickerSetTitle,
+  setStickerSetThumbnail,
+  setCustomEmojiStickerSetThumbnail,
+  deleteStickerSet,
+  answerInlineQuery,
+  answerWebAppQuery,
+  sendInvoice,
+  createInvoiceLink,
+  answerShippingQuery,
+  answerPreCheckoutQuery,
+  setPassportDataErrors,
+  sendGame,
+  setGameScore,
+  getGameHighScores,
 }
 
 /**
@@ -72,4 +270,103 @@ export const object = {
 export const array = [
   getUpdates,
   setWebhook,
+  deleteWebhook,
+  getWebhookInfo,
+  getMe,
+  logOut,
+  close,
+  sendMessage,
+  forwardMessage,
+  copyMessage,
+  sendPhoto,
+  sendAudio,
+  sendDocument,
+  sendVideo,
+  sendAnimation,
+  sendVoice,
+  sendVideoNote,
+  sendMediaGroup,
+  sendLocation,
+  editMessageLiveLocation,
+  stopMessageLiveLocation,
+  sendVenue,
+  sendContact,
+  sendPoll,
+  sendDice,
+  sendChatAction,
+  getUserProfilePhotos,
+  getFile,
+  banChatMember,
+  unbanChatMember,
+  restrictChatMember,
+  promoteChatMember,
+  setChatAdministratorCustomTitle,
+  banChatSenderChat,
+  unbanChatSenderChat,
+  setChatPermissions,
+  exportChatInviteLink,
+  createChatInviteLink,
+  editChatInviteLink,
+  revokeChatInviteLink,
+  approveChatJoinRequest,
+  declineChatJoinRequest,
+  setChatPhoto,
+  deleteChatPhoto,
+  setChatTitle,
+  setChatDescription,
+  pinChatMessage,
+  unpinChatMessage,
+  unpinAllChatMessages,
+  leaveChat,
+  getChat,
+  getChatAdministrators,
+  getChatMemberCount,
+  getChatMember,
+  setChatStickerSet,
+  deleteChatStickerSet,
+  answerCallbackQuery,
+  setMyCommands,
+  deleteMyCommands,
+  getMyCommands,
+  setMyName,
+  getMyName,
+  setMyDescription,
+  getMyDescription,
+  setMyShortDescription,
+  getMyShortDescription,
+  setChatMenuButton,
+  getChatMenuButton,
+  setMyDefaultAdministratorRights,
+  getMyDefaultAdministratorRights,
+  editMessageText,
+  editMessageCaption,
+  editMessageMedia,
+  editMessageReplyMarkup,
+  stopPoll,
+  deleteMessage,
+  sendSticker,
+  getStickerSet,
+  getCustomEmojiStickers,
+  uploadStickerFile,
+  createNewStickerSet,
+  addStickerToSet,
+  setStickerPositionInSet,
+  deleteStickerFromSet,
+  setStickerEmojiList,
+  setStickerKeywords,
+  setStickerMaskPosition,
+  setStickerSetTitle,
+  setStickerSetThumbnail,
+  setCustomEmojiStickerSetThumbnail,
+  deleteStickerSet,
+  answerInlineQuery,
+  answerWebAppQuery,
+  sendInvoice,
+  createInvoiceLink,
+  answerShippingQuery,
+  answerPreCheckoutQuery,
+  setPassportDataErrors,
+  sendGame,
+  setGameScore,
+  getGameHighScores,
 ]

--- a/src/bot-api/types.ts
+++ b/src/bot-api/types.ts
@@ -68,6 +68,146 @@ const Chat = $todo()
 
 const ChatFullInfo = $todo()
 
+const MessageId = $todo()
+
+const MessageEntity = $todo()
+
+const PhotoSize = $todo()
+
+const Animation = $todo()
+
+const Audio = $todo()
+
+const Document = $todo()
+
+const Video = $todo()
+
+const VideoNote = $todo()
+
+const Voice = $todo()
+
+const Contact = $todo()
+
+const Dice = $todo()
+
+const PollOption = $todo()
+
+const PollAnswer = $todo()
+
+const Poll = $todo()
+
+const Location = $todo()
+
+const Venue = $todo()
+
+const WebAppData = $todo()
+
+const ProximityAlertTriggered = $todo()
+
+const MessageAutoDeleteTimerChanged = $todo()
+
+const ForumTopicCreated = $todo()
+
+const ForumTopicEdited = $todo()
+
+const ForumTopicClosed = $todo()
+
+const ForumTopicReopened = $todo()
+
+const GeneralForumTopicHidden = $todo()
+
+const GeneralForumTopicUnhidden = $todo()
+
+const UserShared = $todo()
+
+const ChatShared = $todo()
+
+const WriteAccessAllowed = $todo()
+
+const VideoChatScheduled = $todo()
+
+const VideoChatStarted = $todo()
+
+const VideoChatEnded = $todo()
+
+const VideoChatParticipantsInvited = $todo()
+
+const UserProfilePhotos = $todo()
+
+const File = $todo()
+
+const WebAppInfo = $todo()
+
+const ReplyKeyboardMarkup = $todo()
+
+const KeyboardButton = $todo()
+
+const KeyboardButtonPollType = $todo()
+
+const ReplyKeyboardRemove = $todo()
+
+const InlineKeyboardMarkup = $todo()
+
+const InlineKeyboardButton = $todo()
+
+const LoginUrl = $todo()
+
+const SwitchInlineQueryChosenChat = $todo()
+
+const CallbackQuery = $todo()
+
+const ForceReply = $todo()
+
+const ChatPhoto = $todo()
+
+const ChatInviteLink = $todo()
+
+const ChatAdministratorRights = $todo()
+
+const ChatMember = $todo()
+
+const ChatMemberOwner = $todo()
+
+const ChatMemberAdministrator = $todo()
+
+const ChatMemberMember = $todo()
+
+const ChatMemberRestricted = $todo()
+
+const ChatMemberLeft = $todo()
+
+const ChatMemberBanned = $todo()
+
+const ChatMemberUpdated = $todo()
+
+const ChatPermissions = $todo()
+
+const ChatLocation = $todo()
+
+const ChatJoinRequest = $todo()
+
+const ChatBoost = $todo()
+
+const ChatBoostRemoved = $todo()
+
+const BusinessConnection = $todo()
+
+const BusinessMessagesDeleted = $todo()
+
+const BusinessMessage = $todo()
+
+const MessageReaction = $todo()
+
+const MessageReactionCount = $todo()
+
+const Story = $todo()
+
+const ChatBackground = $todo()
+
+const StoryDeleted = $todo()
+
+const ChatBoostUpdated = $todo()
+
 const Message = defineType({
   name: 'Message',
   description: $descriptionMd(`This object represents a message.`),
@@ -198,6 +338,76 @@ export const object = {
   User,
   Chat,
   ChatFullInfo,
+  MessageId,
+  MessageEntity,
+  PhotoSize,
+  Animation,
+  Audio,
+  Document,
+  Video,
+  VideoNote,
+  Voice,
+  Contact,
+  Dice,
+  PollOption,
+  PollAnswer,
+  Poll,
+  Location,
+  Venue,
+  WebAppData,
+  ProximityAlertTriggered,
+  MessageAutoDeleteTimerChanged,
+  ForumTopicCreated,
+  ForumTopicEdited,
+  ForumTopicClosed,
+  ForumTopicReopened,
+  GeneralForumTopicHidden,
+  GeneralForumTopicUnhidden,
+  UserShared,
+  ChatShared,
+  WriteAccessAllowed,
+  VideoChatScheduled,
+  VideoChatStarted,
+  VideoChatEnded,
+  VideoChatParticipantsInvited,
+  UserProfilePhotos,
+  File,
+  WebAppInfo,
+  ReplyKeyboardMarkup,
+  KeyboardButton,
+  KeyboardButtonPollType,
+  ReplyKeyboardRemove,
+  InlineKeyboardMarkup,
+  InlineKeyboardButton,
+  LoginUrl,
+  SwitchInlineQueryChosenChat,
+  CallbackQuery,
+  ForceReply,
+  ChatPhoto,
+  ChatInviteLink,
+  ChatAdministratorRights,
+  ChatMember,
+  ChatMemberOwner,
+  ChatMemberAdministrator,
+  ChatMemberMember,
+  ChatMemberRestricted,
+  ChatMemberLeft,
+  ChatMemberBanned,
+  ChatMemberUpdated,
+  ChatPermissions,
+  ChatLocation,
+  ChatJoinRequest,
+  ChatBoost,
+  ChatBoostRemoved,
+  BusinessConnection,
+  BusinessMessagesDeleted,
+  BusinessMessage,
+  MessageReaction,
+  MessageReactionCount,
+  Story,
+  ChatBackground,
+  StoryDeleted,
+  ChatBoostUpdated,
   Message,
 }
 
@@ -211,5 +421,75 @@ export const array = [
   User,
   Chat,
   ChatFullInfo,
+  MessageId,
+  MessageEntity,
+  PhotoSize,
+  Animation,
+  Audio,
+  Document,
+  Video,
+  VideoNote,
+  Voice,
+  Contact,
+  Dice,
+  PollOption,
+  PollAnswer,
+  Poll,
+  Location,
+  Venue,
+  WebAppData,
+  ProximityAlertTriggered,
+  MessageAutoDeleteTimerChanged,
+  ForumTopicCreated,
+  ForumTopicEdited,
+  ForumTopicClosed,
+  ForumTopicReopened,
+  GeneralForumTopicHidden,
+  GeneralForumTopicUnhidden,
+  UserShared,
+  ChatShared,
+  WriteAccessAllowed,
+  VideoChatScheduled,
+  VideoChatStarted,
+  VideoChatEnded,
+  VideoChatParticipantsInvited,
+  UserProfilePhotos,
+  File,
+  WebAppInfo,
+  ReplyKeyboardMarkup,
+  KeyboardButton,
+  KeyboardButtonPollType,
+  ReplyKeyboardRemove,
+  InlineKeyboardMarkup,
+  InlineKeyboardButton,
+  LoginUrl,
+  SwitchInlineQueryChosenChat,
+  CallbackQuery,
+  ForceReply,
+  ChatPhoto,
+  ChatInviteLink,
+  ChatAdministratorRights,
+  ChatMember,
+  ChatMemberOwner,
+  ChatMemberAdministrator,
+  ChatMemberMember,
+  ChatMemberRestricted,
+  ChatMemberLeft,
+  ChatMemberBanned,
+  ChatMemberUpdated,
+  ChatPermissions,
+  ChatLocation,
+  ChatJoinRequest,
+  ChatBoost,
+  ChatBoostRemoved,
+  BusinessConnection,
+  BusinessMessagesDeleted,
+  BusinessMessage,
+  MessageReaction,
+  MessageReactionCount,
+  Story,
+  ChatBackground,
+  StoryDeleted,
+  ChatBoostUpdated,
   Message,
 ]


### PR DESCRIPTION
Add all Telegram Bot API methods and types as `$todo` placeholders to prepare for full API implementation.

---
<a href="https://cursor.com/background-agent?bcId=bc-e206462e-1523-4c80-a1f2-2932a8b574d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e206462e-1523-4c80-a1f2-2932a8b574d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

